### PR TITLE
chore: parameterize build output directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  BUILD_OUTPUT_DIR: dist
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ env.BUILD_OUTPUT_DIR }}
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,7 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    outDir: process.env.BUILD_OUTPUT_DIR ?? "dist",
+  },
 }));


### PR DESCRIPTION
## Summary
- configure deploy workflow with `BUILD_OUTPUT_DIR` env variable and use it for artifact upload
- allow Vite builds to honor `BUILD_OUTPUT_DIR` via `build.outDir`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 11 problems, 4 errors, 7 warnings)


------
https://chatgpt.com/codex/tasks/task_e_688ee6ee3fa8832c9dc43ecef368da98