### PR TITLE
chore: make build output directory configurable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: true
 
+env:
+  BUILD_OUTPUT_DIR: dist
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,10 +27,10 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
-      - run: npm run build
+      - run: npm run build -- --outDir $BUILD_OUTPUT_DIR
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: ${{ env.BUILD_OUTPUT_DIR }}
 
   deploy:
     needs: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
-      - run: npm run build -- --outDir $BUILD_OUTPUT_DIR
+      - run: npm run build -- --outDir ${{ env.BUILD_OUTPUT_DIR }}
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ${{ env.BUILD_OUTPUT_DIR }}


### PR DESCRIPTION
## Summary
- use BUILD_OUTPUT_DIR env var in deploy workflow
- build with configured output directory and upload artifact from env var

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 4 errors, 7 warnings)

------
https://chatgpt.com/codex/tasks/task_e_688ef7dab01c832c9b47be642d6b324d