### PR TITLE
chore: make build output directory configurable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: true
 
+env:
+  BUILD_OUTPUT_DIR: dist
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,7 +30,7 @@ jobs:
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: ${{ env.BUILD_OUTPUT_DIR }}
 
   deploy:
     needs: build

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,7 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    outDir: process.env.BUILD_OUTPUT_DIR ?? "dist",
+  },
 }));


### PR DESCRIPTION
## Summary
- use BUILD_OUTPUT_DIR env var in deploy workflow
- configure Vite to respect BUILD_OUTPUT_DIR env var

## Testing
- `BUILD_OUTPUT_DIR=build-output npm run build`
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 4 errors, 7 warnings)


------
https://chatgpt.com/codex/tasks/task_e_688ef7dab01c832c9b47be642d6b324d