### PR TITLE
Fix GitHub Pages deployment base path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - run: cp dist/index.html dist/404.html
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,13 +5,14 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: mode === "production" ? "/express-flow-trainer/" : "/",
   server: {
     host: "::",
     port: 8080,
   },
   plugins: [
     react(),
-    mode === 'development' &&
+    mode === "development" &&
     componentTagger(),
   ].filter(Boolean),
   resolve: {


### PR DESCRIPTION
## Summary
- ensure Vite builds use the repository path so GitHub Pages can find bundled assets
- copy `index.html` to `404.html` during deploy for single-page app routing

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any; An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688efbb90adc832c9393bb354532229e