### PR TITLE
Fix router base path and enable SPA fallback

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=/express-flow-trainer/" />
+    <title>Redirecting...</title>
+  </head>
+  <body></body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/" element={<Index />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}


### PR DESCRIPTION
## Summary
- align React Router basename with Vite base URL
- add 404 page that redirects routes to the SPA entry

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 4 errors, 7 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fb51eea18832cb3fbe9926f4f5cef